### PR TITLE
Sending extended class instances through RPC.

### DIFF
--- a/extensions-samples/gwt/gwt20-rpc/src/main/java/org/atmosphere/samples/client/BaseEvent.java
+++ b/extensions-samples/gwt/gwt20-rpc/src/main/java/org/atmosphere/samples/client/BaseEvent.java
@@ -1,0 +1,10 @@
+package org.atmosphere.samples.client;
+
+public class BaseEvent {
+
+    public boolean baseData;
+
+    public BaseEvent() {
+    }
+
+}

--- a/extensions-samples/gwt/gwt20-rpc/src/main/java/org/atmosphere/samples/client/RPCEvent.java
+++ b/extensions-samples/gwt/gwt20-rpc/src/main/java/org/atmosphere/samples/client/RPCEvent.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
  *
  * @author rinchen tenpel
  */
-public class RPCEvent implements Serializable {
+public class RPCEvent extends BaseEvent implements Serializable {
 
     private String data;
     


### PR DESCRIPTION
This scenario is to send an instance of a third-party library class. Base class does not implement Serializable interface. Serializing base class shouldn't be a problem because it has a public constructor and all fields are public. This isn't very realistic but I wanted to make sure that serialization would be as easy as possible.
