### PR TITLE
Update GWT to 2.5.1

### DIFF
--- a/extensions-samples/gwt/pom.xml
+++ b/extensions-samples/gwt/pom.xml
@@ -16,7 +16,7 @@
     <url>https://github.com/Atmosphere/atmosphere-extensions/gwt20</url>
 
     <properties>
-        <gwt-version>2.5.0</gwt-version>
+        <gwt-version>2.5.1</gwt-version>
     </properties>
 
     <modules>


### PR DESCRIPTION
The 2.5.0 release does not have the necessary dependencies for javax.validation
