### PR TITLE
Copy the web files to the hosted directory for gwt:run

### DIFF
--- a/extensions-samples/gwt/gwt20-jersey-rpc/pom.xml
+++ b/extensions-samples/gwt/gwt20-jersey-rpc/pom.xml
@@ -20,6 +20,7 @@
         <gwt.draftCompile>true</gwt.draftCompile>
         <gwt.style>PRETTY</gwt.style>
         <gwt.compiler.strict>true</gwt.compiler.strict>
+        <gwt.copyWebapp>true</gwt.copyWebapp>
         <outputDir>${war.target}/WEB-INF/classes</outputDir>
     </properties>
 

--- a/extensions-samples/gwt/gwt20-json/pom.xml
+++ b/extensions-samples/gwt/gwt20-json/pom.xml
@@ -20,6 +20,7 @@
         <gwt.draftCompile>true</gwt.draftCompile>
         <gwt.style>PRETTY</gwt.style>
         <gwt.compiler.strict>true</gwt.compiler.strict>
+        <gwt.copyWebapp>true</gwt.copyWebapp>
         <outputDir>${war.target}/WEB-INF/classes</outputDir>
     </properties>
 

--- a/extensions-samples/gwt/gwt20-managed-rpc/pom.xml
+++ b/extensions-samples/gwt/gwt20-managed-rpc/pom.xml
@@ -20,6 +20,7 @@
         <gwt.draftCompile>true</gwt.draftCompile>
         <gwt.style>PRETTY</gwt.style>
         <gwt.compiler.strict>true</gwt.compiler.strict>
+        <gwt.copyWebapp>true</gwt.copyWebapp>
         <outputDir>${war.target}/WEB-INF/classes</outputDir>
     </properties>
 

--- a/extensions-samples/gwt/gwt20-rpc/pom.xml
+++ b/extensions-samples/gwt/gwt20-rpc/pom.xml
@@ -20,6 +20,7 @@
         <gwt.draftCompile>true</gwt.draftCompile>
         <gwt.style>PRETTY</gwt.style>
         <gwt.compiler.strict>true</gwt.compiler.strict>
+        <gwt.copyWebapp>true</gwt.copyWebapp>
         <outputDir>${war.target}/WEB-INF/classes</outputDir>
     </properties>
 


### PR DESCRIPTION
Setting the gwt.copyWebapp to true copies all files from src/main/webapp to the hosted mode directory before starting the GWT development mode. Otherwise you can't use the application because the index.jsp does not exist!
