### PR TITLE
Jackson has problems with similar method signatures

### DIFF
--- a/samples/chat-multiroom/src/main/java/org/atmosphere/samples/chat/ChatProtocol.java
+++ b/samples/chat-multiroom/src/main/java/org/atmosphere/samples/chat/ChatProtocol.java
@@ -79,7 +79,7 @@ public class ChatProtocol implements JacksonEncoder.Encodable {
         return users;
     }
 
-    public void setUsers(Collection<String> users) {
+    public void addUsers(Collection<String> users) {
         this.users.addAll(users);
     }
 

--- a/samples/chat-multiroom/src/main/java/org/atmosphere/samples/chat/ChatRoom.java
+++ b/samples/chat-multiroom/src/main/java/org/atmosphere/samples/chat/ChatRoom.java
@@ -121,7 +121,7 @@ public class ChatRoom {
             return new ChatProtocol(message.getAuthor(), " entered room " + chatroomName, users.keySet(), getRooms(factory.lookupAll()));
         }
 
-        message.setUsers(users.keySet());
+        message.addUsers(users.keySet());
         logger.info("{} just send {}", message.getAuthor(), message.getMessage());
         return new ChatProtocol(message.getAuthor(), message.getMessage(), users.keySet(), getRooms(factory.lookupAll()));
     }


### PR DESCRIPTION
Chat-mutiroom example is not working as expected. Jackson raises exception in decoder when try to decode ChatProtocol. Both setUsers methods are too similar.